### PR TITLE
Apply request-side power scaling to negative totals

### DIFF
--- a/app.py
+++ b/app.py
@@ -709,7 +709,7 @@ def _active_request_ip_count() -> int:
 
 def _apply_request_side_power_scaling(powers: Tuple[float, float, float]) -> Tuple[float, float, float]:
     total = sum(powers)
-    if total <= 0:
+    if total == 0:
         return powers
     count = max(1, _active_request_ip_count())
     if count <= 1:


### PR DESCRIPTION
## Summary
- allow request-side power scaling to run even when the summed phase power is negative so multi-client reads during grid charging are consistent

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68dfbd2d71248332a80cf425659b071b