### PR TITLE
Add `shelly_webapi` input source with multi‑device aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,13 @@ Configuration (env vars)
   - `HA_BASE_URL`: e.g. `http://homeassistant:8123` or `http://192.168.x.x:8123`
   - `HA_TOKEN`: HA Long‑Lived Access Token (read‑only)
   - `POLL_INTERVAL`: seconds between polls (default 2.0)
+  - `INPUT_SOURCE`: source for phase values. Supported: `home_assistant` (default) or `shelly_webapi`
   - `HA_SMOOTHING_ENABLE`: when `true`, average each sensor reading over the last 5 values
   - Entity IDs (override as needed): `A_POWER`, `B_POWER`, `C_POWER`, `A_VOLT`, `B_VOLT`, `C_VOLT`, `A_CURR`, `B_CURR`, `C_CURR`, `A_PF`, `B_PF`, `C_PF`
+  - Shelly upstream source (used when `INPUT_SOURCE=shelly_webapi`)
+    - `SHELLY_BASE_URL`: base URL of one upstream Shelly (for example `http://192.168.1.120`)
+    - `SHELLY_BASE_URLS`: comma-separated list of Shelly base URLs to aggregate (takes precedence over `SHELLY_BASE_URL`)
+    - `SHELLY_TIMEOUT`: HTTP timeout in seconds for Shelly requests (default `3.0`)
 - Device identity
   - `DEVICE_ID`: Device identifier reported in RPC/mDNS (default `shellypro3em-virtual-001`)
   - `APP_ID`: Shelly application identifier (default `shellypro3em`)
@@ -123,6 +128,13 @@ Home Assistant polling
 
 - Each `POLL_INTERVAL`, HA sensors are fetched. Missing or `unknown/unavailable` values are treated as `None` (or `0.0` for power). Phase power values feed energy integration (kWh) over time.
 - Energy counters persist to `STATE_PATH`. You can reset counters via RPC: `EMData.ResetCounters`.
+
+Shelly Web API polling
+
+- When `INPUT_SOURCE=shelly_webapi`, each poll fetches `EM.GetStatus` from one or more configured Shelly devices using HTTP endpoints (`/rpc/EM.GetStatus?id=0`, fallback `/rpc?method=EM.GetStatus&id=0`).
+- For multiple devices (`SHELLY_BASE_URLS`), per-phase values are aggregated:
+  - `a/b/c_act_power` and `a/b/c_current`: summed across Shelly devices.
+  - `a/b/c_voltage` and `a/b/c_pf`: averaged across Shelly devices that returned values.
 
 Shelly app notes
 

--- a/app.py
+++ b/app.py
@@ -47,6 +47,15 @@ HA_TOKEN = os.getenv("HA_TOKEN", "")
 POLL_INTERVAL = float(os.getenv("POLL_INTERVAL", "2.0"))
 HA_SMOOTHING_ENABLE = os.getenv("HA_SMOOTHING_ENABLE", "false").lower() in ("1", "true", "yes")
 HA_SMOOTHING_WINDOW = 5
+INPUT_SOURCE = os.getenv("INPUT_SOURCE", "home_assistant").strip().lower()
+
+SHELLY_BASE_URL = os.getenv("SHELLY_BASE_URL", "").strip().rstrip("/")
+SHELLY_BASE_URLS = [
+    u.strip().rstrip("/")
+    for u in os.getenv("SHELLY_BASE_URLS", "").split(",")
+    if u.strip()
+]
+SHELLY_TIMEOUT = float(os.getenv("SHELLY_TIMEOUT", "3.0"))
 
 A_POWER = os.getenv("A_POWER", "sensor.phase_a_power")
 B_POWER = os.getenv("B_POWER", "sensor.phase_b_power")
@@ -139,6 +148,83 @@ def ha_get(entity_id: str) -> Optional[float]:
         return value
     except Exception:
         return None
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    if value in (None, "unknown", "unavailable", ""):
+        return None
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def _shelly_sources() -> List[str]:
+    if SHELLY_BASE_URLS:
+        return SHELLY_BASE_URLS
+    if SHELLY_BASE_URL:
+        return [SHELLY_BASE_URL]
+    return []
+
+
+def shelly_get_em_status(base_url: str) -> Optional[Dict[str, Any]]:
+    if not base_url:
+        return None
+    headers = {"Content-Type": "application/json"}
+    urls = [
+        f"{base_url}/rpc/EM.GetStatus?id=0",
+        f"{base_url}/rpc?method=EM.GetStatus&id=0",
+    ]
+    for url in urls:
+        try:
+            r = requests.get(url, headers=headers, timeout=SHELLY_TIMEOUT)
+            if r.status_code != 200:
+                continue
+            data = r.json()
+            if isinstance(data, dict):
+                # Support direct result and JSON-RPC envelope
+                if "result" in data and isinstance(data["result"], dict):
+                    return data["result"]
+                return data
+        except Exception:
+            continue
+    return None
+
+
+def shelly_get_em_status_aggregated() -> Dict[str, float]:
+    totals: Dict[str, float] = {
+        "a_act_power": 0.0,
+        "b_act_power": 0.0,
+        "c_act_power": 0.0,
+        "a_voltage": 0.0,
+        "b_voltage": 0.0,
+        "c_voltage": 0.0,
+        "a_current": 0.0,
+        "b_current": 0.0,
+        "c_current": 0.0,
+        "a_pf": 0.0,
+        "b_pf": 0.0,
+        "c_pf": 0.0,
+    }
+    contributors = {k: 0 for k in totals}
+
+    for source in _shelly_sources():
+        status = shelly_get_em_status(source)
+        if not status:
+            continue
+        for key in totals:
+            value = _coerce_float(status.get(key))
+            if value is None:
+                continue
+            totals[key] += value
+            contributors[key] += 1
+
+    # Keep voltages and power factors realistic when aggregating multiple meters:
+    # use average for V/PF, sum for powers/currents.
+    for key in ("a_voltage", "b_voltage", "c_voltage", "a_pf", "b_pf", "c_pf"):
+        if contributors[key] > 0:
+            totals[key] = totals[key] / contributors[key]
+    return totals
 
 
 _SMOOTHING_LOCK = threading.RLock()
@@ -291,18 +377,36 @@ class VirtualPro3EM:
 
     def poll_home_assistant(self):
         try:
-            a_w = ha_get(A_POWER) or 0.0
-            b_w = ha_get(B_POWER) or 0.0
-            c_w = ha_get(C_POWER) or 0.0
-            a_volt = ha_get(A_VOLT)
-            b_volt = ha_get(B_VOLT)
-            c_volt = ha_get(C_VOLT)
-            a_curr = ha_get(A_CURR)
-            b_curr = ha_get(B_CURR)
-            c_curr = ha_get(C_CURR)
-            a_pf = ha_get(A_PF) or None
-            b_pf = ha_get(B_PF) or None
-            c_pf = ha_get(C_PF) or None
+            if INPUT_SOURCE == "shelly_webapi":
+                status = shelly_get_em_status_aggregated()
+                a_w = _coerce_float(status.get("a_act_power")) or 0.0
+                b_w = _coerce_float(status.get("b_act_power")) or 0.0
+                c_w = _coerce_float(status.get("c_act_power")) or 0.0
+
+                a_volt = _coerce_float(status.get("a_voltage"))
+                b_volt = _coerce_float(status.get("b_voltage"))
+                c_volt = _coerce_float(status.get("c_voltage"))
+
+                a_curr = _coerce_float(status.get("a_current"))
+                b_curr = _coerce_float(status.get("b_current"))
+                c_curr = _coerce_float(status.get("c_current"))
+
+                a_pf = _coerce_float(status.get("a_pf")) or None
+                b_pf = _coerce_float(status.get("b_pf")) or None
+                c_pf = _coerce_float(status.get("c_pf")) or None
+            else:
+                a_w = ha_get(A_POWER) or 0.0
+                b_w = ha_get(B_POWER) or 0.0
+                c_w = ha_get(C_POWER) or 0.0
+                a_volt = ha_get(A_VOLT)
+                b_volt = ha_get(B_VOLT)
+                c_volt = ha_get(C_VOLT)
+                a_curr = ha_get(A_CURR)
+                b_curr = ha_get(B_CURR)
+                c_curr = ha_get(C_CURR)
+                a_pf = ha_get(A_PF) or None
+                b_pf = ha_get(B_PF) or None
+                c_pf = ha_get(C_PF) or None
             with self.lock:
                 self.phases["a"].act_power = float(a_w)
                 self.phases["b"].act_power = float(b_w)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,10 @@ services:
       HA_BASE_URL: "http://192.168.2.225:8123"
       HA_TOKEN: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI0M2M0MTdlYTk1NmE0YjRhOTkxMWE2ZmZiMDBkM2NhZiIsImlhdCI6MTc1OTE2NzUyOCwiZXhwIjoyMDc0NTI3NTI4fQ.e1sJ6xlkH4YgM9ld3L00Ztsi_g3xQ-dLggEOLXeRDaM"
       POLL_INTERVAL: "2.0"
+      INPUT_SOURCE: "home_assistant"   # or "shelly_webapi"
+      # SHELLY_BASE_URL: "http://192.168.1.120"
+      # SHELLY_BASE_URLS: "http://192.168.1.120,http://192.168.1.121"
+      # SHELLY_TIMEOUT: "3.0"
 
       DEVICE_ID: "485519d74a28"
       MODEL: "SPEM-003CEBEU"


### PR DESCRIPTION
### Motivation

- Provide an alternative input source to Home Assistant by polling Shelly devices directly over their Web API and support aggregating values from multiple Shelly devices.
- Allow deployments without HA or combine readings from several Shelly meters into the virtual device.

### Description

- Added new environment configuration: `INPUT_SOURCE`, `SHELLY_BASE_URL`, `SHELLY_BASE_URLS`, and `SHELLY_TIMEOUT` and documented them in `README.md` and `docker-compose.yaml` examples.
- Implemented helper functions `shelly_get_em_status`, `_shelly_sources`, `_coerce_float`, and `shelly_get_em_status_aggregated` to fetch and aggregate `/rpc/EM.GetStatus` responses across one or more Shelly devices.
- Updated `poll_home_assistant` logic to use `INPUT_SOURCE == "shelly_webapi"` to source phase power/voltage/current/pf values from the aggregated Shelly results, preserving existing HA behavior otherwise.
- Aggregation semantics: sum phase powers and currents, and average voltages and power factors across contributors.

### Testing

- No automated tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6983176948332b946ec292066b163)