### PR TITLE
Apply static total power offsets for outbound status

### DIFF
--- a/app.py
+++ b/app.py
@@ -364,6 +364,13 @@ def _apply_request_side_power_scaling(powers: Tuple[float, float, float]) -> Tup
         return powers
     return tuple(p / count for p in powers)
 
+def _apply_total_power_offset(total_power: float) -> float:
+    if total_power > 0:
+        return total_power - 200.0
+    if total_power < 0:
+        return total_power - 50.0
+    return total_power
+
 
 def _smooth_value(entity_id: str, value: float) -> float:
     with _SMOOTHING_LOCK:
@@ -541,7 +548,7 @@ class VirtualPro3EM:
                 float(c.act_power or 0.0),
             )
             a_power, b_power, c_power = _apply_request_side_power_scaling(raw_powers)
-            total_w = a_power + b_power + c_power
+            total_w = _apply_total_power_offset(a_power + b_power + c_power)
 
             if STRICT_MINIMAL_PAYLOAD:
                 # Minimal contract: only the 4 power keys some gateways require
@@ -769,7 +776,7 @@ if StartAsyncTcpServer is not None:
                 float(phases["c"].act_power or 0.0),
             )
             a_power, b_power, c_power = _apply_request_side_power_scaling(raw_powers)
-            total_power = a_power + b_power + c_power
+            total_power = _apply_total_power_offset(a_power + b_power + c_power)
             self._write_pair(regs, 3020, _pack_register_pair(a_power, ">f"))
             self._write_pair(regs, 3022, _pack_register_pair(b_power, ">f"))
             self._write_pair(regs, 3024, _pack_register_pair(c_power, ">f"))
@@ -1690,7 +1697,7 @@ def _udp_build_response(obj: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         a = _udp_decimal_enforcer(scaled[0])
         b = _udp_decimal_enforcer(scaled[1])
         c = _udp_decimal_enforcer(scaled[2])
-        total = round(sum(scaled), 3)
+        total = round(_apply_total_power_offset(sum(scaled)), 3)
         if total == round(total) or total == 0:
             total = total + 0.001
         return {
@@ -1712,7 +1719,7 @@ def _udp_build_response(obj: Dict[str, Any]) -> Optional[Dict[str, Any]]:
                 float(VM.phases["c"].act_power or 0.0),
             )
         scaled = _apply_request_side_power_scaling(raw_powers)
-        total = round(sum(scaled), 3)
+        total = round(_apply_total_power_offset(sum(scaled)), 3)
         if total == round(total) or total == 0:
             total = total + 0.001
         return {

--- a/virtual_shelly/rpc_core.py
+++ b/virtual_shelly/rpc_core.py
@@ -75,6 +75,13 @@ def _udp_decimal_enforcer(power: float) -> float:
     add = decimal_point_enforcer if (p == round(p) or p == 0) else 0.0
     return round(p + add, 1)
 
+def _apply_total_power_offset(total_power: float) -> float:
+    if total_power > 0:
+        return total_power - 200.0
+    if total_power < 0:
+        return total_power - 50.0
+    return total_power
+
 
 def udp_build_response(vm, device_id: str, obj: Dict[str, Any]) -> Dict[str, Any] | None:
     # Implement Shelly-like UDP RPC used by b2500-meter (not JSON-RPC 2.0)
@@ -97,7 +104,7 @@ def udp_build_response(vm, device_id: str, obj: Dict[str, Any]) -> Dict[str, Any
         a = _udp_decimal_enforcer(powers[0])
         b = _udp_decimal_enforcer(powers[1])
         c = _udp_decimal_enforcer(powers[2])
-        total = round(sum(powers), 3)
+        total = round(_apply_total_power_offset(sum(powers)), 3)
         if total == round(total) or total == 0:
             total = total + 0.001
         return {
@@ -118,7 +125,7 @@ def udp_build_response(vm, device_id: str, obj: Dict[str, Any]) -> Dict[str, Any
                 vm.phases["b"].act_power or 0.0,
                 vm.phases["c"].act_power or 0.0,
             ]
-        total = round(sum(powers), 3)
+        total = round(_apply_total_power_offset(sum(powers)), 3)
         if total == round(total) or total == 0:
             total = total + 0.001
         return {
@@ -130,4 +137,3 @@ def udp_build_response(vm, device_id: str, obj: Dict[str, Any]) -> Dict[str, Any
     else:
         # Unknown methods: silently ignore (b2500-meter behavior)
         return None
-


### PR DESCRIPTION
### Motivation
- Introduce a fixed offset to reported total power to reduce reported draw for consumers and avoid stuttering/feed-in as requested.
- Ensure the same offset behavior is applied consistently across HTTP/WS RPC, Modbus image, and UDP responses so all external consumers see the adjusted total.

### Description
- Added helper `def _apply_total_power_offset(total_power: float) -> float` to centralize the offset logic which returns `total - 200.0` when total > 0, `total - 50.0` when total < 0, and unchanged when total == 0.
- Applied the offset in the HTTP/WS RPC `EM.GetStatus` path by calling `_apply_total_power_offset(...)` before setting `total_act_power`.
- Applied the offset to the Modbus register image `total_power` field in `build_image` so registers reflect the adjusted total.
- Mirrored the same helper and applied it in both UDP response implementations (`EM.GetStatus` / `EM1.GetStatus`) in `app.py` and `virtual_shelly/rpc_core.py` so UDP outputs also use the adjusted total.

### Testing
- Ran `python -m py_compile app.py virtual_shelly/rpc_core.py` and the files compiled successfully with no syntax errors.
- Verified module-level consistency by inspecting updated `EM.GetStatus` and UDP response code paths in both modules; no automated test suite was executed beyond bytecode compilation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8dc78da848332931f1d143793aa47)