### PR TITLE
Add forecast training controls and sample counts to UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1240,6 +1240,12 @@ def metrics():
     return PlainTextResponse(MET.metrics_text(len(WS_RPC_CLIENTS)))
 
 
+@app.post("/admin/forecast/train")
+def admin_forecast_train():
+    started = FORECAST.launch_training()
+    status = FORECAST.status()
+    return JSONResponse({"started": started, "forecast": status})
+
 @app.get("/admin/overview")
 def admin_overview():
     # WS connected IPs (best-effort)

--- a/virtual_shelly/forecast.py
+++ b/virtual_shelly/forecast.py
@@ -171,9 +171,36 @@ class ForecastManager:
         except Exception:
             return tuple(map(float, actual)), False
 
+    def sample_counts(self) -> Tuple[int, int]:
+        if not self.store:
+            return 0, 0
+        try:
+            total = len(supervised(self.store.read(), self.config.horizon)[0])
+        except Exception:
+            return 0, 0
+        if total < 2:
+            return total, 0
+        train = max(1, min(total - 1, int(total * (1 - self.config.validation_fraction))))
+        return train, total - train
+
+    def _reap_process(self) -> None:
+        if self.process is not None and self.process.poll() is not None:
+            self.process = None
+
+    def launch_training(self) -> bool:
+        if not self.config.enabled:
+            return False
+        self._reap_process()
+        if self.process is not None:
+            return False
+        self.process = subprocess.Popen([sys.executable, "-m", "virtual_shelly.train_forecast"])
+        return True
+
     def status(self) -> Dict[str, Any]:
         self.reload()
+        self._reap_process()
         running = self.process is not None and self.process.poll() is None
+        training_samples, current_validation_samples = self.sample_counts()
         return {
             "enabled": self.config.enabled,
             "available": bool(self.models),
@@ -182,9 +209,13 @@ class ForecastManager:
             "horizon_seconds": self.config.horizon * self.poll_interval,
             "validation_mape": self.metadata.get("validation_mape"),
             "phase_mape": self.metadata.get("phase_mape", {}),
+            "training_samples": training_samples,
             "validation_samples": self.metadata.get("validation_samples"),
+            "current_validation_samples": current_validation_samples,
+            "min_samples": self.config.min_samples,
             "trained_at": self.metadata.get("trained_at"),
             "training": running,
+            "training_status": "running" if running else ("ready" if training_samples + current_validation_samples >= self.config.min_samples else "collecting_data"),
         }
 
     def maybe_launch_training(self, now: Optional[datetime] = None) -> None:
@@ -192,8 +223,6 @@ class ForecastManager:
             return
         now = now or datetime.now()
         today = now.date().isoformat()
-        if self.process is not None and self.process.poll() is not None:
-            self.process = None
-        if now.hour == self.config.train_hour and self.last_launch_date != today and self.process is None:
-            self.process = subprocess.Popen([sys.executable, "-m", "virtual_shelly.train_forecast"])
+        self._reap_process()
+        if now.hour == self.config.train_hour and self.last_launch_date != today and self.launch_training():
             self.last_launch_date = today

--- a/virtual_shelly/ui.py
+++ b/virtual_shelly/ui.py
@@ -14,6 +14,8 @@ def dashboard_html() -> str:
     .header { display:flex; justify-content:space-between; align-items:flex-start; gap:16px; }
     .forecast { min-width:230px; background:#f6f8fa; border:1px solid #d8dee4; border-radius:8px; padding:10px 12px; }
     .forecast strong { font-size:18px; display:block; }
+    .forecast button { margin-top:8px; padding:6px 10px; border:1px solid #0969da; border-radius:6px; background:#0969da; color:white; cursor:pointer; }
+    .forecast button:disabled { background:#8c959f; border-color:#8c959f; cursor:not-allowed; }
     h2 { font-size: 16px; margin: 18px 0 10px 0; }
     .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
     .card { border: 1px solid #e2e2e2; border-radius: 8px; padding: 12px; }
@@ -40,6 +42,21 @@ def dashboard_html() -> str:
       return String(n);
     }
 
+    async function startTraining() {
+      const button = document.getElementById('forecast-train');
+      button.disabled = true;
+      button.textContent = 'Starting…';
+      try {
+        const res = await fetch('/admin/forecast/train', {method: 'POST'});
+        await res.json();
+        await fetchOverview();
+      } catch (e) {
+        console.error('Training start error', e);
+        button.disabled = false;
+        button.textContent = 'Start training';
+      }
+    }
+
     function render(d) {
       const dev = d.device || {};
       document.getElementById('device').textContent = (dev.id || 'device') + ' (' + (dev.model || '') + ' ' + (dev.ver || '') + ')';
@@ -47,7 +64,16 @@ def dashboard_html() -> str:
       const forecast = d.forecast || {};
       document.getElementById('forecast-mape').textContent = forecast.validation_mape == null ? 'MAPE unavailable' : `MAPE ${fmt(forecast.validation_mape)}%`;
       document.getElementById('forecast-detail').textContent = `${forecast.serving || 'fallback_actual'} · N+${forecast.horizon_steps || '-'} (${fmt(forecast.horizon_seconds, 0)}s)`;
-      document.getElementById('forecast-trained').textContent = forecast.trained_at ? `Trained ${new Date(forecast.trained_at).toLocaleString()}` : 'Collecting training data';
+      const training = Boolean(forecast.training);
+      const status = forecast.training_status || (training ? 'running' : 'idle');
+      const trainSamples = forecast.training_samples ?? 0;
+      const validationSamples = forecast.current_validation_samples ?? forecast.validation_samples ?? 0;
+      const minSamples = forecast.min_samples ?? '-';
+      document.getElementById('forecast-trained').textContent = forecast.trained_at ? `Trained ${new Date(forecast.trained_at).toLocaleString()}` : 'No trained model yet';
+      document.getElementById('forecast-status').textContent = `Status ${status.replace('_', ' ')} · train ${trainSamples} / validation ${validationSamples} samples · min ${minSamples}`;
+      const trainButton = document.getElementById('forecast-train');
+      trainButton.disabled = training || forecast.enabled === false;
+      trainButton.textContent = training ? 'Training…' : 'Start training';
 
       const em = (d.values && d.values.em) || {};
       const emdata = (d.values && d.values.emdata) || {};
@@ -125,7 +151,7 @@ def dashboard_html() -> str:
 <body>
   <div class="header">
     <div><h1>Virtual Shelly 3EM Pro — Status <span class="muted" id="device"></span></h1><div class="muted">Updated: <span id="updated">-</span></div></div>
-    <div class="forecast"><strong id="forecast-mape">MAPE unavailable</strong><div id="forecast-detail" class="muted">Loading forecast status</div><div id="forecast-trained" class="muted"></div></div>
+    <div class="forecast"><strong id="forecast-mape">MAPE unavailable</strong><div id="forecast-detail" class="muted">Loading forecast status</div><div id="forecast-status" class="muted">Status unknown</div><div id="forecast-trained" class="muted"></div><button id="forecast-train" type="button" onclick="startTraining()">Start training</button></div>
   </div>
 
   <div class="grid">


### PR DESCRIPTION
### Motivation

- Surface forecast training progress and sample counts in the dashboard and allow operators to trigger training from the UI so the forecast lifecycle can be observed and manually started when needed.

### Description

- Add a `POST /admin/forecast/train` endpoint that returns whether a training process was started and the latest forecast status.  
- Extend `ForecastManager` with `sample_counts()`, `_reap_process()`, and `launch_training()` to compute current train/validation sample counts, clean up finished child processes, and provide a reusable training start routine.  
- Enrich the forecast status payload from `ForecastManager.status()` with `training_samples`, `current_validation_samples`, `min_samples`, and a `training_status` string, and use `_reap_process()` when reporting.  
- Update the dashboard HTML/JS to show the training/validation sample counts and human-friendly status and add a `Start training` button that calls the new `POST /admin/forecast/train` endpoint and disables itself while starting.

### Testing

- Ran `python -m py_compile app.py virtual_shelly/forecast.py virtual_shelly/ui.py` and it succeeded.  
- Running `pytest -q` without `PYTHONPATH` initially failed due to import resolution, which is unrelated to the code changes.  
- Running `PYTHONPATH=. pytest -q` produced `9 passed` and all unit tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72c81269e883328f3328172bb8e265)