### PR TITLE
Install OpenMP runtime (libgomp1) for LightGBM and document requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Quick Start (Docker Compose)
 Manual Run (no Docker)
 
 - Python 3.11+
+- LightGBM requires the OpenMP runtime (`libgomp.so.1` on Linux; e.g. install `libgomp1` on Debian/Ubuntu).
 - `pip install -r requirements.txt`
 - `uvicorn app:app --host 0.0.0.0 --port 80`
 

--- a/dockerfile
+++ b/dockerfile
@@ -5,7 +5,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 COPY requirements.txt /app/
-RUN pip install --no-cache-dir -r requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libgomp1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt
 
 # Copy application code
 COPY app.py /app/app.py


### PR DESCRIPTION
### Motivation

- Prevent training failures that occur when LightGBM cannot load the OpenMP runtime (`libgomp.so.1`) in the container during `start training`.

### Description

- Install the OpenMP runtime package `libgomp1` in the container image before installing Python dependencies by updating `dockerfile` to run `apt-get install -y --no-install-recommends libgomp1` prior to `pip install -r requirements.txt`.
- Document the OpenMP/runtime requirement for manual (non-Docker) installs by adding a note to `README.md` about `libgomp.so.1` (e.g. `libgomp1` on Debian/Ubuntu).

### Testing

- Ran unit tests with `python -m unittest tests/test_forecast.py tests/test_power.py`, all tests passed (`OK`).
- Verified LightGBM imports with `python -c "import lightgbm; print(lightgbm.__version__)"`, which returned the installed version successfully.
- Attempted to run `docker build -f dockerfile -t virtual-shelly3empro:test .` but the environment does not have `docker` installed, so an image build could not be executed here (command failed with `docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73204ff64483328ff153f09ce5e74d)