### PR TITLE
Cache forecast predictions for half a second

### DIFF
--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -49,6 +49,23 @@ class ForecastTests(unittest.TestCase):
             self.assertEqual(manager.predict((1, 2, 3)), ((1.0, 2.0, 3.0), False))
             self.assertEqual(manager.status()["serving"], "fallback_actual")
 
+    def test_manager_caches_prediction_for_half_a_second(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = ForecastConfig(history_path=str(Path(tmp) / "history.db"), model_dir=str(Path(tmp) / "model"))
+            manager = ForecastManager(config, 2.0)
+            for i in range(max(LAGS) + 1):
+                manager.store.append(float(i), (i, i * 2, i * 3))
+            model = unittest.mock.Mock()
+            model.predict.return_value = [42.0]
+            manager.models = {phase: model for phase in ("a", "b", "c")}
+
+            with patch.object(manager, "reload"), patch("virtual_shelly.forecast.time.monotonic", side_effect=[1.0, 1.1, 1.4, 1.6, 1.7]):
+                self.assertEqual(manager.predict((1, 2, 3)), ((42.0, 42.0, 42.0), True))
+                self.assertEqual(manager.predict((4, 5, 6)), ((42.0, 42.0, 42.0), True))
+                self.assertEqual(manager.predict((7, 8, 9)), ((42.0, 42.0, 42.0), True))
+
+            self.assertEqual(model.predict.call_count, 6)
+
     def test_daily_scheduler_only_launches_once(self):
         with tempfile.TemporaryDirectory() as tmp:
             config = ForecastConfig(history_path=str(Path(tmp) / "history.db"), model_dir=str(Path(tmp) / "model"), train_hour=2)

--- a/virtual_shelly/forecast.py
+++ b/virtual_shelly/forecast.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 PHASES = ("a", "b", "c")
 LAGS = (1, 2, 3, 5, 10, 30)
+PREDICTION_CACHE_SECONDS = 0.5
 
 
 def _env_bool(name: str, default: str) -> bool:
@@ -125,6 +126,8 @@ class ForecastManager:
         self.metadata_mtime = 0.0
         self.process: Optional[subprocess.Popen] = None
         self.last_launch_date: Optional[str] = None
+        self.cached_prediction: Optional[Tuple[float, float, float]] = None
+        self.cached_prediction_at = 0.0
         self.reload()
 
     @property
@@ -151,6 +154,8 @@ class ForecastManager:
             with self.lock:
                 self.models, self.metadata = models, metadata
                 self.metadata_mtime = path.stat().st_mtime
+                self.cached_prediction = None
+                self.cached_prediction_at = 0.0
         except Exception:
             return
 
@@ -160,13 +165,18 @@ class ForecastManager:
             return tuple(map(float, actual)), False
         try:
             import numpy as np
-            rows = self.store.read()
-            if len(rows) <= max(LAGS):
-                return tuple(map(float, actual)), False
-            row = make_feature(rows, len(rows) - 1)
             with self.lock:
+                now = time.monotonic()
+                if self.cached_prediction is not None and now - self.cached_prediction_at < PREDICTION_CACHE_SECONDS:
+                    return self.cached_prediction, True
+                rows = self.store.read()
+                if len(rows) <= max(LAGS):
+                    return tuple(map(float, actual)), False
+                row = make_feature(rows, len(rows) - 1)
                 matrix = np.asarray([row], dtype=float)
                 result = tuple(float(self.models[p].predict(matrix)[0]) for p in PHASES)
+                self.cached_prediction = result
+                self.cached_prediction_at = time.monotonic()
             return result, True
         except Exception:
             return tuple(map(float, actual)), False


### PR DESCRIPTION
### Motivation

- Reduce repeated expensive model inference when `ForecastManager.predict` is called in rapid succession by caching recent successful predictions for 0.5 seconds.
- Prevent redundant concurrent inference work and ensure callers receive a stable value during short bursts of calls.

### Description

- Add `PREDICTION_CACHE_SECONDS = 0.5` and instance fields `cached_prediction` and `cached_prediction_at` to `ForecastManager` to store the last successful prediction and its monotonic timestamp.
- Short-circuit `predict` to return the cached result while the cache is fresh, using `time.monotonic()` and synchronizing access with the existing `self.lock` to avoid duplicate inferences under concurrency.
- Invalidate the cache when models are reloaded by resetting `cached_prediction` and `cached_prediction_at` inside `reload` while holding the lock.
- Add the unit test `test_manager_caches_prediction_for_half_a_second` to `tests/test_forecast.py` to verify cache hits and expiry behavior.

### Testing

- Ran `python -m unittest discover -s tests -v` which executed the test suite including the new `test_manager_caches_prediction_for_half_a_second`, and all tests passed (10 tests ran, OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76d29943748332bf100249b9a0c118)