### PR TITLE
Serve fresh forecast values to clients in round‑robin order

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Example Commands
 Home Assistant polling
 
 - Each `POLL_INTERVAL`, HA sensors are fetched. Missing or `unknown/unavailable` values are treated as `None` (or `0.0` for power). Phase power values feed energy integration (kWh) over time.
+- Power results are not cached across clients. After one client receives the current result, another request waits for a fresh source poll, so multiple batteries are served in round-robin order rather than reacting simultaneously to the same change.
 - Energy counters persist to `STATE_PATH`. You can reset counters via RPC: `EMData.ResetCounters`.
 
 Shelly Web API polling

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -2,6 +2,7 @@ import tempfile
 import unittest
 import json
 import os
+import threading
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
@@ -74,7 +75,7 @@ class ForecastTests(unittest.TestCase):
             self.assertEqual(manager.predict((1, 2, 3)), ((1.0, 2.0, 3.0), False))
             self.assertEqual(manager.status()["serving"], "fallback_actual")
 
-    def test_manager_caches_prediction_for_half_a_second(self):
+    def test_manager_waits_for_a_new_source_value_between_clients(self):
         with tempfile.TemporaryDirectory() as tmp:
             config = ForecastConfig(history_path=str(Path(tmp) / "history.db"), model_dir=str(Path(tmp) / "model"))
             manager = ForecastManager(config, 2.0)
@@ -84,11 +85,17 @@ class ForecastTests(unittest.TestCase):
             model.predict.return_value = [42.0]
             manager.models = {phase: model for phase in ("a", "b", "c")}
 
-            with patch.object(manager, "reload"), patch("virtual_shelly.forecast.time.monotonic", side_effect=[1.0, 1.1, 1.4, 1.6, 1.7]):
+            with patch.object(manager, "reload"):
                 self.assertEqual(manager.predict((1, 2, 3)), ((42.0, 42.0, 42.0), True))
-                self.assertEqual(manager.predict((4, 5, 6)), ((42.0, 42.0, 42.0), True))
-                self.assertEqual(manager.predict((7, 8, 9)), ((42.0, 42.0, 42.0), True))
+                result = []
+                waiter = threading.Thread(target=lambda: result.append(manager.predict((4, 5, 6))))
+                waiter.start()
+                self.assertTrue(waiter.is_alive())
+                manager.record((10, 20, 30), ts=100.0)
+                waiter.join(timeout=1)
 
+            self.assertFalse(waiter.is_alive())
+            self.assertEqual(result, [((42.0, 42.0, 42.0), True)])
             self.assertEqual(model.predict.call_count, 6)
 
     def test_daily_scheduler_only_launches_once(self):

--- a/virtual_shelly/forecast.py
+++ b/virtual_shelly/forecast.py
@@ -20,7 +20,6 @@ PHASES = ("a", "b", "c")
 DEFAULT_WINDOW_SIZE = 5
 # Kept as a compatibility alias for callers that used the old maximum lag.
 LAGS = tuple(range(1, DEFAULT_WINDOW_SIZE + 1))
-PREDICTION_CACHE_SECONDS = 0.5
 
 
 def _env_bool(name: str, default: str) -> bool:
@@ -132,8 +131,13 @@ class ForecastManager:
         self.metadata_mtime = 0.0
         self.process: Optional[subprocess.Popen] = None
         self.last_launch_date: Optional[str] = None
-        self.cached_prediction: Optional[Tuple[float, float, float]] = None
-        self.cached_prediction_at = 0.0
+        # A source sample may only satisfy one caller.  Serialising callers here
+        # prevents several batteries from reacting to the same rise or fall.
+        self.source_condition = threading.Condition()
+        self.source_generation = 0
+        self.served_generation = -1
+        self.next_client_ticket = 0
+        self.serving_client_ticket = 0
         self.reload()
 
     @property
@@ -144,6 +148,9 @@ class ForecastManager:
         if not self.store:
             return
         self.store.append(ts or time.time(), powers)
+        with self.source_condition:
+            self.source_generation += 1
+            self.source_condition.notify_all()
         if int(ts or time.time()) % 3600 < max(2, int(self.poll_interval)):
             self.store.prune(time.time() - self.config.retention_days * 86400)
 
@@ -165,32 +172,41 @@ class ForecastManager:
             with self.lock:
                 self.models, self.metadata = models, metadata
                 self.metadata_mtime = path.stat().st_mtime
-                self.cached_prediction = None
-                self.cached_prediction_at = 0.0
         except Exception:
             return
 
     def predict(self, actual: Sequence[float]) -> Tuple[Tuple[float, float, float], bool]:
-        self.reload()
-        if not self.store or not self.models:
+        if not self.store:
             return tuple(map(float, actual)), False
-        try:
-            import numpy as np
-            with self.lock:
-                now = time.monotonic()
-                if self.cached_prediction is not None and now - self.cached_prediction_at < PREDICTION_CACHE_SECONDS:
-                    return self.cached_prediction, True
-                rows = self.store.read()
-                if len(rows) < self.config.window_size:
+
+        # Keep the condition held through inference and generation bookkeeping:
+        # one newly recorded source value is consequently handed to one waiting
+        # client, and the following client waits for the next poll.
+        with self.source_condition:
+            ticket = self.next_client_ticket
+            self.next_client_ticket += 1
+            while ticket != self.serving_client_ticket or self.source_generation <= self.served_generation:
+                self.source_condition.wait()
+            generation = self.source_generation
+            self.reload()
+            try:
+                if not self.models:
                     return tuple(map(float, actual)), False
-                row = make_feature(rows, len(rows) - 1, self.config.window_size)
-                matrix = np.asarray([row], dtype=float)
-                result = tuple(float(self.models[p].predict(matrix)[0]) for p in PHASES)
-                self.cached_prediction = result
-                self.cached_prediction_at = time.monotonic()
-            return result, True
-        except Exception:
-            return tuple(map(float, actual)), False
+                import numpy as np
+                with self.lock:
+                    rows = self.store.read()
+                    if len(rows) < self.config.window_size:
+                        return tuple(map(float, actual)), False
+                    row = make_feature(rows, len(rows) - 1, self.config.window_size)
+                    matrix = np.asarray([row], dtype=float)
+                    result = tuple(float(self.models[p].predict(matrix)[0]) for p in PHASES)
+                return result, True
+            except Exception:
+                return tuple(map(float, actual)), False
+            finally:
+                self.served_generation = generation
+                self.serving_client_ticket += 1
+                self.source_condition.notify_all()
 
     def sample_counts(self) -> Tuple[int, int]:
         if not self.store:


### PR DESCRIPTION
### Motivation

- Prevent multiple batteries/clients from reacting to the same source sample by removing the short-lived cached forecast and serialising client servicing so each client gets a fresh source value.
- Ensure that a second client waits until a new poll/source sample has been recorded before receiving a forecast, producing round‑robin behaviour across clients.

### Description

- Removed the previous half‑second forecast cache and introduced a `Condition`‑based generation counter and ticketing mechanism in `ForecastManager` to serialise clients and ensure each served forecast corresponds to a newly recorded source sample (`virtual_shelly/forecast.py`).
- On `record()` increment the source generation and notify waiters so blocked clients resume only after a fresh reading is appended (`virtual_shelly/forecast.py`).
- Replaced the cache regression test with a thread‑based test that verifies a waiting client is blocked until a new source value is recorded (`tests/test_forecast.py`).
- Documented the new multi‑battery / round‑robin behaviour in the `README.md`.

### Testing

- Ran `PYTHONPATH=. pytest -q` and all tests passed (`13 passed`).
- Ran `PYTHONPATH=. python -m unittest discover -s tests -v` and all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76e9f94f148332b2ae6264838c3e71)