### PR TITLE
Buffer forecast/energy writes and flush to disk hourly

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Features
   - Read-only input/holding registers share the same data; writing `1` to holding register `4200` resets the virtual energy counters.
   - Defaults to TCP port 502 with unit ID 1 (configurable via env vars).
 - mDNS service advertisements (`_http._tcp` and `_shelly._tcp`) for discovery.
-- Energy counters integrated from power over time and persisted at `/data/state.json` (via Docker volume).
+- Energy counters integrated from power over time and persisted hourly at `/data/state.json` (via Docker volume).
  - LightGBM forecasts replace phase and total power in Shelly responses. Raw readings are retained for energy integration, while the dashboard reports validation MAPE and model status.
  - Simple `/metrics` endpoint with Prometheus‑style counters for HTTP/WS/UDP events.
 
@@ -100,10 +100,11 @@ Configuration (env vars)
   - `STRICT_MINIMAL_PAYLOAD`: when `true`, HTTP/WS `EM.GetStatus` returns only `{a_act_power,b_act_power,c_act_power,total_act_power}` (some gateways prefer this).
 - Persistence
   - `STATE_PATH`: defaults to `/data/state.json` (mounted via volume in Compose).
+  - Energy state and forecast observations are buffered in memory and flushed to disk once every 60 minutes to limit disk churn. A shutdown between flushes can therefore lose up to one hour of new data.
 - Forecasting
   - `FORECAST_ENABLE`: enable history collection and forecasts (default `true`). Until a model is available, current readings are returned.
   - `FORECAST_HORIZON_STEPS`: number of polling steps ahead to predict (default `1`; a step is `POLL_INTERVAL`). Changing it invalidates the active model and triggers a complete cold retrain for the new target window.
-  - `FORECAST_HISTORY_PATH`: SQLite observation store (default `/data/power_history.sqlite3`).
+  - `FORECAST_HISTORY_PATH`: SQLite observation store (default `/data/power_history.sqlite3`); new observations are written in hourly batches.
   - `FORECAST_MODEL_DIR`: promoted LightGBM models and metrics (default `/data/forecast_model`).
   - `FORECAST_TRAIN_HOUR`: local hour for daily child-process training (default `2`).
   - `FORECAST_MIN_SAMPLES`: minimum supervised samples required to train (default `1000`).

--- a/app.py
+++ b/app.py
@@ -6,7 +6,6 @@ import socket
 import asyncio
 import logging
 import struct
-import signal
 from datetime import datetime, timezone
 from typing import Dict, Any, Optional, List, Tuple, Deque
 from collections import defaultdict, deque
@@ -92,6 +91,7 @@ MANUFACTURER = os.getenv("MANUFACTURER", "Allterco Robotics")
 GENERATION = int(os.getenv("GENERATION", "2"))
 
 STATE_PATH = os.getenv("STATE_PATH", "/data/state.json")
+DISK_FLUSH_INTERVAL_SECONDS = 60 * 60
 
 # Networking
 HTTP_PORT = int(os.getenv("HTTP_PORT", "8080"))
@@ -523,8 +523,8 @@ class VirtualPro3EM:
                     self.integrate_energy(dt)
             self.last_poll_mono = now_mono
 
-            # Persist every 30s using monotonic cadence
-            if (now_mono - self.last_persist_mono) >= 30.0:
+            # Batch disk writes on an hourly cadence to reduce storage churn.
+            if (now_mono - self.last_persist_mono) >= DISK_FLUSH_INTERVAL_SECONDS:
                 self.persist()
                 self.last_persist_mono = now_mono
         except Exception:
@@ -601,7 +601,6 @@ class VirtualPro3EM:
     def emdata_reset_counters(self, _params: Dict[str, Any]) -> Dict[str, Any]:
         with self.lock:
             self.energy = EnergyCounters(since=now_ts())
-            self.persist()
         if MODBUS_BRIDGE:
             MODBUS_BRIDGE.update()
         return {"ok": True, "ts": now_ts()}
@@ -1958,18 +1957,3 @@ def start_mdns():
     threading.Thread(target=_register, daemon=True).start()
 
 start_mdns()
-
-# -----------------------------
-# Graceful shutdown: persist energy on SIGTERM/SIGINT
-# -----------------------------
-def _handle_term(signum, frame):
-    try:
-        VM.persist()
-    except Exception:
-        pass
-
-try:
-    signal.signal(signal.SIGTERM, _handle_term)
-    signal.signal(signal.SIGINT, _handle_term)
-except Exception:
-    pass

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -67,6 +67,18 @@ class ForecastTests(unittest.TestCase):
             store.append(1, (1, 2, 3))
             self.assertEqual([row[0] for row in store.read()], [1.0, 2.0])
             self.assertEqual([row[0] for row in store.read(cutoff=1.5)], [2.0])
+            self.assertEqual(HistoryStore(str(Path(tmp) / "history.db")).read(), [])
+            store.flush()
+            self.assertEqual([row[0] for row in HistoryStore(str(Path(tmp) / "history.db")).read()], [1.0, 2.0])
+
+    def test_history_flushes_buffer_after_sixty_minutes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = HistoryStore(str(Path(tmp) / "history.db"))
+            store.append(1, (1, 2, 3))
+            with patch("virtual_shelly.forecast.time.monotonic", return_value=store.last_flush_mono + 3600):
+                store.append(2, (4, 5, 6))
+            reopened = HistoryStore(str(Path(tmp) / "history.db"))
+            self.assertEqual([row[0] for row in reopened.read()], [1.0, 2.0])
 
     def test_manager_falls_back_without_a_model(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/virtual_shelly/forecast.py
+++ b/virtual_shelly/forecast.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 PHASES = ("a", "b", "c")
 DEFAULT_WINDOW_SIZE = 5
+DISK_FLUSH_INTERVAL_SECONDS = 60 * 60
 # Kept as a compatibility alias for callers that used the old maximum lag.
 LAGS = tuple(range(1, DEFAULT_WINDOW_SIZE + 1))
 
@@ -64,6 +65,9 @@ def mape(actual: Sequence[float], predicted: Sequence[float], floor: float = 10.
 class HistoryStore:
     def __init__(self, path: str):
         self.path = path
+        self.lock = threading.RLock()
+        self.pending: Dict[float, Tuple[float, float, float]] = {}
+        self.last_flush_mono = time.monotonic()
         Path(path).parent.mkdir(parents=True, exist_ok=True)
         with self._connect() as db:
             db.execute("CREATE TABLE IF NOT EXISTS power (ts REAL PRIMARY KEY, a REAL, b REAL, c REAL)")
@@ -71,19 +75,56 @@ class HistoryStore:
     def _connect(self):
         return sqlite3.connect(self.path, timeout=10)
 
-    def append(self, ts: float, powers: Sequence[float]) -> None:
-        with self._connect() as db:
-            db.execute("INSERT OR REPLACE INTO power VALUES (?, ?, ?, ?)", (ts, *map(float, powers)))
+    def append(
+        self, ts: float, powers: Sequence[float], prune_before: Optional[float] = None
+    ) -> None:
+        values = tuple(map(float, powers))
+        if len(values) != 3:
+            raise ValueError("power history requires exactly three phase values")
+        with self.lock:
+            self.pending[float(ts)] = values
+            if time.monotonic() - self.last_flush_mono >= DISK_FLUSH_INTERVAL_SECONDS:
+                self.pending = {
+                    pending_ts: pending_powers
+                    for pending_ts, pending_powers in self.pending.items()
+                    if prune_before is None or pending_ts >= prune_before
+                }
+                self.flush(prune_before=prune_before)
+
+    def flush(self, prune_before: Optional[float] = None) -> None:
+        """Commit buffered observations in one transaction at the hourly boundary."""
+        with self.lock:
+            if not self.pending and prune_before is None:
+                self.last_flush_mono = time.monotonic()
+                return
+            rows = [(ts, *powers) for ts, powers in self.pending.items()]
+            with self._connect() as db:
+                if rows:
+                    db.executemany("INSERT OR REPLACE INTO power VALUES (?, ?, ?, ?)", rows)
+                if prune_before is not None:
+                    db.execute("DELETE FROM power WHERE ts < ?", (prune_before,))
+            self.pending.clear()
+            self.last_flush_mono = time.monotonic()
 
     def read(self, cutoff: Optional[float] = None) -> List[Tuple[float, float, float, float]]:
-        with self._connect() as db:
-            if cutoff is None:
-                return list(db.execute("SELECT ts,a,b,c FROM power ORDER BY ts"))
-            return list(db.execute("SELECT ts,a,b,c FROM power WHERE ts >= ? ORDER BY ts", (cutoff,)))
+        with self.lock:
+            with self._connect() as db:
+                if cutoff is None:
+                    rows = list(db.execute("SELECT ts,a,b,c FROM power ORDER BY ts"))
+                else:
+                    rows = list(db.execute("SELECT ts,a,b,c FROM power WHERE ts >= ? ORDER BY ts", (cutoff,)))
+            merged = {row[0]: row for row in rows}
+            merged.update(
+                (ts, (ts, *powers))
+                for ts, powers in self.pending.items()
+                if cutoff is None or ts >= cutoff
+            )
+            return [merged[ts] for ts in sorted(merged)]
 
     def prune(self, cutoff: float) -> None:
-        with self._connect() as db:
-            db.execute("DELETE FROM power WHERE ts < ?", (cutoff,))
+        with self.lock:
+            self.pending = {ts: powers for ts, powers in self.pending.items() if ts >= cutoff}
+            self.flush(prune_before=cutoff)
 
 
 def feature_names(window_size: int = DEFAULT_WINDOW_SIZE) -> List[str]:
@@ -147,12 +188,15 @@ class ForecastManager:
     def record(self, powers: Sequence[float], ts: Optional[float] = None) -> None:
         if not self.store:
             return
-        self.store.append(ts or time.time(), powers)
+        now = time.time()
+        self.store.append(
+            ts or now,
+            powers,
+            prune_before=now - self.config.retention_days * 86400,
+        )
         with self.source_condition:
             self.source_generation += 1
             self.source_condition.notify_all()
-        if int(ts or time.time()) % 3600 < max(2, int(self.poll_interval)):
-            self.store.prune(time.time() - self.config.retention_days * 86400)
 
     def reload(self) -> None:
         path = self.metadata_path


### PR DESCRIPTION
### Motivation
- Reduce disk churn by batching frequent small writes for forecast observations and energy counters into hourly commits. 
- Keep recent observations available in-memory for serving and forecasting while limiting on-disk persistence frequency.
- Avoid immediate disk writes on energy counter resets or shutdown to honor the new hourly flush cadence.

### Description
- Add `DISK_FLUSH_INTERVAL_SECONDS = 60 * 60` and implement an in-memory buffer in `HistoryStore` (`pending`, `lock`, `last_flush_mono`).
- Change `HistoryStore.append` to buffer observations and add `flush(prune_before: Optional[float])` to atomically commit buffered rows and perform retention pruning.
- Make `HistoryStore.read` merge pending in-memory observations with on-disk rows so reads see recent samples before flushes, and change `prune` to filter pending items then call `flush`.
- Update `ForecastManager.record` to pass a `prune_before` timestamp and use the buffered append (retention pruning is performed during hourly flushes).
- Move energy persistence in `app.py` from a 30s cadence to the hourly `DISK_FLUSH_INTERVAL_SECONDS` cadence and avoid persisting on `emdata_reset_counters`, so resets no longer force immediate disk writes.
- Document the durability tradeoff in `README.md` (hourly flushes and potential loss of up to one hour of data if the service stops before a flush).
- Add tests in `tests/test_forecast.py` that verify the buffer is memory-only until `flush()`/hourly boundary and that buffered rows are persisted after the flush.

### Testing
- Ran the full unit test suite with `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -v` and all tests passed (`Ran 14 tests ... OK`).
- Verified code sanity with `python -m compileall` and checked diffs using `git diff --check`; no issues were reported.
- Added new unit tests covering buffer flush behavior, which succeed under the test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76fb2c26608332ba0af34be34a5569)