### PR TITLE
Serve clients in-turn without waiting for new source polls (configurable interval)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Configuration (env vars)
   - `FORECAST_VALIDATION_FRACTION`: newest chronological fraction used for validation (default `0.2`).
   - `FORECAST_HISTORY_DAYS`: observation retention period (default `30`).
   - `FORECAST_MAPE_FLOOR_WATTS`: denominator floor used by MAPE around zero (default `10`).
+  - `FORECAST_SERVE_INTERVAL`: seconds between serving consecutive power consumers (default `0.25`). Requests are served in arrival order using the latest available reading instead of waiting for a new source poll.
   - Training uses all observations retained by `FORECAST_HISTORY_DAYS` (30 days by default). Daily training warm-starts each phase model from the active LightGBM booster. A candidate is atomically promoted only when its mean phase validation MAPE is under 10% and beats the incumbent on the same validation slice. Until a qualifying model exists for the configured horizon and input window, current readings are returned as the fallback.
 
 APIs
@@ -148,7 +149,7 @@ Example Commands
 Home Assistant polling
 
 - Each `POLL_INTERVAL`, HA sensors are fetched. Missing or `unknown/unavailable` values are treated as `None` (or `0.0` for power). Phase power values feed energy integration (kWh) over time.
-- Power results are not cached across clients. After one client receives the current result, another request waits for a fresh source poll, so multiple batteries are served in round-robin order rather than reacting simultaneously to the same change.
+- Power consumers are served one at a time, in arrival order, with `FORECAST_SERVE_INTERVAL` between them. Each consumer receives the latest available result immediately after that short delay; requests do not wait for a fresh source poll.
 - Energy counters persist to `STATE_PATH`. You can reset counters via RPC: `EMData.ResetCounters`.
 
 Shelly Web API polling

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -3,6 +3,7 @@ import unittest
 import json
 import os
 import threading
+import time
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
@@ -23,6 +24,10 @@ class ForecastTests(unittest.TestCase):
     def test_input_window_comes_from_environment(self):
         with patch.dict(os.environ, {"FORECAST_WINDOW_SIZE": "12"}, clear=True):
             self.assertEqual(ForecastConfig.from_env().window_size, 12)
+
+    def test_serve_interval_comes_from_environment(self):
+        with patch.dict(os.environ, {"FORECAST_SERVE_INTERVAL": "0.4"}, clear=True):
+            self.assertEqual(ForecastConfig.from_env().serve_interval, 0.4)
 
     def test_input_vector_contains_configured_number_of_readings(self):
         rows = [(float(i), float(i), float(i * 2), float(i * 3)) for i in range(12)]
@@ -87,9 +92,13 @@ class ForecastTests(unittest.TestCase):
             self.assertEqual(manager.predict((1, 2, 3)), ((1.0, 2.0, 3.0), False))
             self.assertEqual(manager.status()["serving"], "fallback_actual")
 
-    def test_manager_waits_for_a_new_source_value_between_clients(self):
+    def test_manager_serves_clients_in_turn_without_waiting_for_new_data(self):
         with tempfile.TemporaryDirectory() as tmp:
-            config = ForecastConfig(history_path=str(Path(tmp) / "history.db"), model_dir=str(Path(tmp) / "model"))
+            config = ForecastConfig(
+                history_path=str(Path(tmp) / "history.db"),
+                model_dir=str(Path(tmp) / "model"),
+                serve_interval=0.05,
+            )
             manager = ForecastManager(config, 2.0)
             for i in range(max(LAGS) + 1):
                 manager.store.append(float(i), (i, i * 2, i * 3))
@@ -102,8 +111,8 @@ class ForecastTests(unittest.TestCase):
                 result = []
                 waiter = threading.Thread(target=lambda: result.append(manager.predict((4, 5, 6))))
                 waiter.start()
+                time.sleep(0.01)
                 self.assertTrue(waiter.is_alive())
-                manager.record((10, 20, 30), ts=100.0)
                 waiter.join(timeout=1)
 
             self.assertFalse(waiter.is_alive())

--- a/virtual_shelly/forecast.py
+++ b/virtual_shelly/forecast.py
@@ -39,6 +39,7 @@ class ForecastConfig:
     validation_fraction: float = 0.2
     retention_days: int = 30
     mape_floor_watts: float = 10.0
+    serve_interval: float = 0.25
 
     @classmethod
     def from_env(cls) -> "ForecastConfig":
@@ -53,6 +54,7 @@ class ForecastConfig:
             validation_fraction=min(.4, max(.05, float(os.getenv("FORECAST_VALIDATION_FRACTION", ".2")))),
             retention_days=max(1, int(os.getenv("FORECAST_HISTORY_DAYS", "30"))),
             mape_floor_watts=max(.001, float(os.getenv("FORECAST_MAPE_FLOOR_WATTS", "10"))),
+            serve_interval=max(0.0, float(os.getenv("FORECAST_SERVE_INTERVAL", ".25"))),
         )
 
 
@@ -172,13 +174,13 @@ class ForecastManager:
         self.metadata_mtime = 0.0
         self.process: Optional[subprocess.Popen] = None
         self.last_launch_date: Optional[str] = None
-        # A source sample may only satisfy one caller.  Serialising callers here
-        # prevents several batteries from reacting to the same rise or fall.
-        self.source_condition = threading.Condition()
-        self.source_generation = 0
-        self.served_generation = -1
+        # Serialize consumers without making them wait for another source poll.
+        # A short gap keeps multiple batteries from reacting at exactly the same
+        # instant while ensuring every request receives the latest known value.
+        self.serve_condition = threading.Condition()
         self.next_client_ticket = 0
         self.serving_client_ticket = 0
+        self.last_served_mono: Optional[float] = None
         self.reload()
 
     @property
@@ -194,9 +196,6 @@ class ForecastManager:
             powers,
             prune_before=now - self.config.retention_days * 86400,
         )
-        with self.source_condition:
-            self.source_generation += 1
-            self.source_condition.notify_all()
 
     def reload(self) -> None:
         path = self.metadata_path
@@ -223,15 +222,16 @@ class ForecastManager:
         if not self.store:
             return tuple(map(float, actual)), False
 
-        # Keep the condition held through inference and generation bookkeeping:
-        # one newly recorded source value is consequently handed to one waiting
-        # client, and the following client waits for the next poll.
-        with self.source_condition:
+        # Keep the condition held through inference and bookkeeping so callers
+        # are served in arrival order, separated by the configured short gap.
+        with self.serve_condition:
             ticket = self.next_client_ticket
             self.next_client_ticket += 1
-            while ticket != self.serving_client_ticket or self.source_generation <= self.served_generation:
-                self.source_condition.wait()
-            generation = self.source_generation
+            while ticket != self.serving_client_ticket:
+                self.serve_condition.wait()
+            if self.last_served_mono is not None:
+                while (remaining := self.config.serve_interval - (time.monotonic() - self.last_served_mono)) > 0:
+                    self.serve_condition.wait(timeout=remaining)
             self.reload()
             try:
                 if not self.models:
@@ -248,9 +248,9 @@ class ForecastManager:
             except Exception:
                 return tuple(map(float, actual)), False
             finally:
-                self.served_generation = generation
+                self.last_served_mono = time.monotonic()
                 self.serving_client_ticket += 1
-                self.source_condition.notify_all()
+                self.serve_condition.notify_all()
 
     def sample_counts(self) -> Tuple[int, int]:
         if not self.store:


### PR DESCRIPTION
### Motivation

- Prevent multiple clients from blocking while waiting for a fresh source poll and improve responsiveness by serving recent readings immediately in sequence.
- Provide a configurable short gap between serving consecutive clients so multiple consumers don't react at exactly the same instant.

### Description

- Add `serve_interval` to `ForecastConfig` and a new environment variable `FORECAST_SERVE_INTERVAL` (default `0.25`) to control the delay between serving clients via `ForecastConfig.serve_interval`.
- Replace the previous wait-for-new-source behavior in `ForecastManager.predict` with a ticketed, condition-based serializer (`serve_condition`, `next_client_ticket`, `serving_client_ticket`, `last_served_mono`) that serves callers in arrival order and sleeps up to `serve_interval` between them.
- Remove the older source-generation caching logic and adapt `record`/`reload` bookkeeping accordingly so each request receives the latest available reading without requiring a new poll.
- Update `README.md` to document `FORECAST_SERVE_INTERVAL` and adjust behavior text, and extend `tests/test_forecast.py` to verify the new configuration and serving behavior.

### Testing

- Ran the test suite with `python -m unittest discover -s tests -v` and all tests passed (15 tests, OK).
- Ran `python -m compileall` on `app.py`, `virtual_shelly` and `tests` to validate byte-compilation with no errors.
- Verified repository sanity checks (`git diff --check`) and local status showed the working tree clean after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76fd376f1483329ce67564420dae78)