### PR TITLE
Default to stable multi-device load sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Configuration (env vars)
   - `HA_TOKEN`: HA Long‑Lived Access Token (read‑only)
   - `POLL_INTERVAL`: seconds between polls (default 2.0)
   - `INPUT_SOURCE`: source for phase values. Supported: `home_assistant` (default) or `shelly_webapi`
-  - `HA_SMOOTHING_ENABLE`: when `true`, average each sensor reading over the last 5 values
+  - `HA_SMOOTHING_ENABLE`: average each sensor reading over the last 3 values (default `true`; set to `false` to disable)
   - Entity IDs (override as needed): `A_POWER`, `B_POWER`, `C_POWER`, `A_VOLT`, `B_VOLT`, `C_VOLT`, `A_CURR`, `B_CURR`, `C_CURR`, `A_PF`, `B_PF`, `C_PF`
   - Shelly upstream source (used when `INPUT_SOURCE=shelly_webapi`)
     - `SHELLY_BASE_URL`: base URL of one upstream Shelly (for example `http://192.168.1.120`)
@@ -77,9 +77,9 @@ Configuration (env vars)
   - `WS_NOTIFY_EPS`: coalescing threshold in watts; only broadcast when change ≥ EPS (default `0.1`).
   - `CORS_ENABLE`: enable CORS middleware (`true|false`, default `false`).
   - `CORS_ORIGINS`: comma‑separated allowed origins (default `*`).
-  - Request‑side scaling (divide power by active client IPs)
+  - Request‑side scaling (divide power among active client IPs minus one, so multiple batteries share the load without oscillating)
     - `REQUEST_SIDE_SCALING_ENABLE`: `true|false` (default `true`)
-    - `REQUEST_SIDE_SCALING_CLIENTS`: integer override for client count (default `0` = auto by active IPs)
+    - `REQUEST_SIDE_SCALING_CLIENTS`: integer override for asking-device count (default `0` = auto by active IPs); the divisor is this count minus one, with a minimum of one
   - Total power offsets
     - `POSITIVE_POWER_OFFSET`: watts subtracted when total power is positive (default `10.0`)
     - `NEGATIVE_POWER_OFFSET`: watts subtracted when total power is negative (default `10.0`)

--- a/app.py
+++ b/app.py
@@ -46,8 +46,8 @@ from pydantic import BaseModel
 HA_BASE_URL = os.getenv("HA_BASE_URL", "http://homeassistant:8123")
 HA_TOKEN = os.getenv("HA_TOKEN", "")
 POLL_INTERVAL = float(os.getenv("POLL_INTERVAL", "2.0"))
-HA_SMOOTHING_ENABLE = os.getenv("HA_SMOOTHING_ENABLE", "false").lower() in ("1", "true", "yes")
-HA_SMOOTHING_WINDOW = 5
+HA_SMOOTHING_ENABLE = os.getenv("HA_SMOOTHING_ENABLE", "true").lower() in ("1", "true", "yes")
+HA_SMOOTHING_WINDOW = 3
 INPUT_SOURCE = os.getenv("INPUT_SOURCE", "home_assistant").strip().lower()
 
 SHELLY_BASE_URL = os.getenv("SHELLY_BASE_URL", "").strip().rstrip("/")
@@ -127,7 +127,7 @@ WS_NOTIFY_EPS = float(os.getenv("WS_NOTIFY_EPS", "0.1"))
 CORS_ENABLE = os.getenv("CORS_ENABLE", "false").lower() in ("1", "true", "yes")
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "*")
 
-# Request-side scaling (divide power by number of active client IPs)
+# Request-side scaling (divide power among active client IPs, excluding one)
 REQUEST_SIDE_SCALING_ENABLE = os.getenv("REQUEST_SIDE_SCALING_ENABLE", "true").lower() in ("1", "true", "yes")
 try:
     REQUEST_SIDE_SCALING_CLIENTS = int(os.getenv("REQUEST_SIDE_SCALING_CLIENTS", "0"))  # 0 = auto count
@@ -361,10 +361,13 @@ def _apply_request_side_power_scaling(powers: Tuple[float, float, float]) -> Tup
     # Allow explicit override of active client count via env; 0 means auto
     override = int(REQUEST_SIDE_SCALING_CLIENTS or 0)
     count = override if override > 0 else _active_request_ip_count()
-    count = max(1, count)
-    if count <= 1:
+    # One active IP is the monitoring/controller device rather than a battery.
+    # Excluding it prevents each battery from reacting to the full load, which
+    # otherwise makes multi-battery systems oscillate.
+    divisor = max(1, count - 1)
+    if divisor <= 1:
         return powers
-    return tuple(p / count for p in powers)
+    return tuple(p / divisor for p in powers)
 
 def _smooth_value(entity_id: str, value: float) -> float:
     with _SMOOTHING_LOCK:

--- a/tests/test_app_defaults.py
+++ b/tests/test_app_defaults.py
@@ -1,0 +1,37 @@
+import os
+
+
+os.environ["MDNS_ENABLE"] = "false"
+os.environ.pop("HA_SMOOTHING_ENABLE", None)
+
+import app
+
+
+def setup_function():
+    app._SMOOTHING_BUFFERS.clear()
+    app._REQUEST_IP_SEEN.clear()
+
+
+def test_smoothing_defaults_to_three_datapoints():
+    assert app.HA_SMOOTHING_ENABLE is True
+    assert app.HA_SMOOTHING_WINDOW == 3
+    assert app._smooth_value("sensor.power", 3.0) == 3.0
+    assert app._smooth_value("sensor.power", 6.0) == 4.5
+    assert app._smooth_value("sensor.power", 9.0) == 6.0
+    assert app._smooth_value("sensor.power", 12.0) == 9.0
+
+
+def test_request_scaling_splits_over_asking_devices_minus_one(monkeypatch):
+    monkeypatch.setattr(app, "REQUEST_SIDE_SCALING_ENABLE", True)
+    monkeypatch.setattr(app, "REQUEST_SIDE_SCALING_CLIENTS", 0)
+    monkeypatch.setattr(app, "_active_request_ip_count", lambda: 4)
+
+    assert app._apply_request_side_power_scaling((90.0, 60.0, 30.0)) == (30.0, 20.0, 10.0)
+
+
+def test_request_scaling_divisor_has_minimum_of_one(monkeypatch):
+    monkeypatch.setattr(app, "REQUEST_SIDE_SCALING_ENABLE", True)
+    monkeypatch.setattr(app, "REQUEST_SIDE_SCALING_CLIENTS", 0)
+    monkeypatch.setattr(app, "_active_request_ip_count", lambda: 2)
+
+    assert app._apply_request_side_power_scaling((90.0, 60.0, 30.0)) == (90.0, 60.0, 30.0)


### PR DESCRIPTION
### Motivation
- Prevent oscillation in multi-battery setups by ensuring the reported load is shared across actual asking devices rather than each battery reacting to the full load. 
- Reduce noise from Home Assistant sensor reads by applying a short smoothing window by default.

### Description
- Enable Home Assistant smoothing by default and set the smoothing window to three datapoints via `HA_SMOOTHING_ENABLE` and `HA_SMOOTHING_WINDOW` in `app.py`.
- Change request-side scaling logic in `app.py` so power is divided by `(active_clients - 1)` (minimum divisor of 1) to exclude the controller/monitor device from the per-battery split. 
- Update `README.md` to document the new smoothing default and the updated request-side scaling semantics and environment variables. 
- Add `tests/test_app_defaults.py` with unit tests for the three-datapoint smoothing behavior and the new request-side-scaling divisor and minimum-divisor behavior.

### Testing
- Ran the test suite with `python -m pytest -q` and all tests passed: `18 passed, 4 warnings`.
- New unit tests exercise the smoothing default and the request-side scaling logic and succeeded in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a774d82df4c8332b53dc7859700e77c)